### PR TITLE
[DMX] Do not include the IP if it's nil (DMX-700)

### DIFF
--- a/forensiq.go
+++ b/forensiq.go
@@ -211,7 +211,9 @@ func (f *Forensiq) Ready(ctx context.Context) (bool, error) {
 
 func (cr CheckRequest) toValues() url.Values {
 	v := url.Values{}
-	v.Set("ip", cr.IP.String())
+	if cr.IP != nil {
+		v.Set("ip", cr.IP.String())
+	}
 	v.Set("rt", cr.RequestType)
 	v.Set("url", cr.URL)
 	v.Set("seller", cr.SellerID)


### PR DESCRIPTION
if the IP is nil, do not call `.String()` on it.

JIRA Issues: DMX-700
